### PR TITLE
Split input and actions

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,92 @@
+use crate::{seek, AppState, OrbitCamera, PlayMode, PlaybackControl, ShaderService};
+use glam::Vec2;
+use winit::event_loop::ControlFlow;
+
+pub enum Action {
+    AppExit,
+    TimePlay,
+    TimePause,
+    TogglePlayPause,
+    TimeStop,
+    TimeForward(f32),
+    TimeRewind(f32),
+    WindowClose,
+    WindowResize((i32, i32)),
+    // size
+    CameraToggleIntegration(bool),
+    CameraReset,
+}
+
+pub fn handle_actions(
+    actions: &mut Vec<Action>,
+    app_state: &mut AppState,
+    shader_service: &mut ShaderService,
+    control_flow: &mut ControlFlow,
+) {
+    for action in actions.drain(..) {
+        match action {
+            Action::AppExit => {
+                log::info!("Bye now...");
+                app_state.is_running = false;
+                *control_flow = ControlFlow::Exit
+            }
+            Action::TimePlay => {
+                app_state.timer.start();
+                app_state.play_mode = PlayMode::Playing;
+            }
+            Action::TimePause => {
+                app_state.play_mode = PlayMode::Paused;
+            }
+            Action::TimeStop => {
+                app_state.playback_time = seek(app_state.playback_time, PlaybackControl::Stop)
+            }
+            Action::TogglePlayPause => match app_state.play_mode {
+                PlayMode::Playing => {
+                    app_state.play_mode = PlayMode::Paused;
+                }
+                PlayMode::Paused => {
+                    app_state.timer.start();
+                    app_state.play_mode = PlayMode::Playing;
+                }
+            },
+            Action::TimeForward(time) => {
+                app_state.playback_time =
+                    seek(app_state.playback_time, PlaybackControl::Forward(time))
+            }
+            Action::TimeRewind(time) => {
+                app_state.playback_time =
+                    seek(app_state.playback_time, PlaybackControl::Rewind(time))
+            }
+            Action::WindowClose => {}
+            Action::WindowResize((width, height)) => {
+                app_state.width = width;
+                app_state.height = height;
+            }
+            Action::CameraToggleIntegration(use_camera_integration) => match use_camera_integration
+            {
+                true => {
+                    if !shader_service.use_camera_integration {
+                        log::info!("Enabling camera integration. Please use '#pragma skuggbox(camera)' in your shader");
+                        shader_service.use_camera_integration = true;
+                        shader_service
+                            .reload()
+                            .expect("Expected successful shader reload");
+                    }
+                }
+                false => {
+                    if shader_service.use_camera_integration {
+                        log::info!("Disabling camera integration");
+                        shader_service.use_camera_integration = false;
+                        shader_service
+                            .reload()
+                            .expect("Expected successful shader reload");
+                    }
+                }
+            },
+            Action::CameraReset => {
+                app_state.camera = Box::from(OrbitCamera::default());
+                app_state.mouse.delta = Vec2::new(0.0, 0.0);
+            }
+        }
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,13 +2,12 @@ use winit::event_loop::EventLoop;
 use winit::platform::run_return::EventLoopExtRunReturn;
 
 use crate::{
-    get_uniform_location, handle_events, AppState, AppWindow, Buffer, Config, PlayMode,
-    ShaderService, SkuggboxShader, Timer,
+    handle_events, AppState, AppWindow, Buffer, Config, PlayMode, ShaderService, SkuggboxShader,
+    Timer,
 };
 
 pub struct App {
     pub event_loop: EventLoop<()>,
-    // pub window_context: ContextWrapper<PossiblyCurrent, Window>,
     pub app_window: AppWindow,
     pub state: AppState,
 }
@@ -117,10 +116,10 @@ fn render(
         let transform = state.camera.calculate_uniform_data();
         let position = transform.w_axis;
 
-        let location = get_uniform_location(program, "sbCameraPosition");
+        let location = program.uniform_location("sbCameraPosition");
         gl::Uniform3f(location, position.x, position.y, position.z);
 
-        let location = get_uniform_location(program, "sbCameraTransform");
+        let location = program.uniform_location("sbCameraTransform");
         gl::UniformMatrix4fv(location, 1, gl::FALSE, &transform.to_cols_array()[0]);
 
         gl::Clear(gl::COLOR_BUFFER_BIT);
@@ -131,6 +130,5 @@ fn render(
     }
 
     unsafe { gl::UseProgram(0) };
-    // window_context.swap_buffers().unwrap();
     app_window.window_context.swap_buffers().unwrap();
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,18 +3,20 @@
 pub enum BufferType {
     VertexBuffer,
     IndexBuffer,
+    FrameBuffer,
 }
 
 #[derive(Clone, Debug)]
 pub struct Buffer {
     pub gl_buffer: gl::types::GLuint,
-    pub size: gl::types::GLsizeiptr,
+    // TODO(mathias): Add buffer_type and examine if we need to expose buffer size or not
 }
 
 fn get_buffer_type(buffer_type: BufferType) -> gl::types::GLenum {
     match buffer_type {
         BufferType::VertexBuffer => gl::ARRAY_BUFFER,
         BufferType::IndexBuffer => gl::ELEMENT_ARRAY_BUFFER,
+        BufferType::FrameBuffer => gl::FRAMEBUFFER,
     }
 }
 
@@ -26,11 +28,8 @@ impl Buffer {
             1.0, -1.0, 0.0, // 2
             -1.0, -1.0, 0.0, // 3
         ];
-        Buffer::vertex_buffer(BufferType::VertexBuffer, &vertices)
-    }
 
-    pub fn vertex_buffer(buffer_type: BufferType, vertices: &[f32]) -> Self {
-        let buf_type = get_buffer_type(buffer_type);
+        let buffer_type = get_buffer_type(BufferType::VertexBuffer);
         let size = (vertices.len() * std::mem::size_of::<f32>()) as gl::types::GLsizeiptr;
 
         let mut vbo: gl::types::GLuint = 0;
@@ -38,12 +37,12 @@ impl Buffer {
             gl::GenBuffers(1, &mut vbo);
             gl::BindBuffer(gl::ARRAY_BUFFER, vbo);
             gl::BufferData(
-                buf_type,                                      // target
+                buffer_type,                                   // target
                 size,                                          // size of data in bytes
                 vertices.as_ptr() as *const gl::types::GLvoid, // pointer to data
                 gl::STATIC_DRAW,                               // usage
             );
-            gl::BindBuffer(buf_type, 0);
+            gl::BindBuffer(buffer_type, 0);
         }
 
         // set up vertex array object
@@ -51,7 +50,7 @@ impl Buffer {
         unsafe {
             gl::GenVertexArrays(1, &mut vao);
             gl::BindVertexArray(vao);
-            gl::BindBuffer(buf_type, vbo);
+            gl::BindBuffer(buffer_type, vbo);
             gl::EnableVertexAttribArray(0); // this is "layout (location = 0)" in vertex shader
             gl::VertexAttribPointer(
                 0,         // index of the generic vertex attribute ("layout (location = 0)")
@@ -61,14 +60,11 @@ impl Buffer {
                 (3 * std::mem::size_of::<f32>()) as gl::types::GLint, // stride (byte offset between consecutive attributes)
                 std::ptr::null(), // offset of the first component
             );
-            gl::BindBuffer(buf_type, 0);
+            gl::BindBuffer(buffer_type, 0);
             gl::BindVertexArray(0);
         }
 
-        Self {
-            gl_buffer: vao,
-            size,
-        }
+        Self { gl_buffer: vao }
     }
 
     pub fn bind(&self) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,26 +1,21 @@
-use crate::{
-    buffer::Buffer,
-    state::{seek, AppState, PlayMode, PlaybackControl},
-    timer::Timer,
-    OrbitCamera, ShaderService, WindowEventHandler,
-};
-use glam::Vec2;
 use glutin::{ContextWrapper, PossiblyCurrent};
-use log::info;
 use winit::{
     event::{ElementState, Event, VirtualKeyCode, WindowEvent},
     event_loop::ControlFlow,
     window::Window,
 };
 
+use crate::{
+    state::{AppState, PlayMode},
+    Action, WindowEventHandler,
+};
+
 pub fn handle_events<T>(
     event: &Event<'_, T>,
     control_flow: &mut ControlFlow,
-    world_state: &mut AppState,
-    timer: &mut Timer,
+    app_state: &mut AppState,
     context: &ContextWrapper<PossiblyCurrent, Window>,
-    buffer: &Buffer,
-    shader: &mut ShaderService,
+    actions: &mut Vec<Action>,
 ) {
     *control_flow = ControlFlow::Poll;
     context.swap_buffers().unwrap();
@@ -29,17 +24,12 @@ pub fn handle_events<T>(
         Event::WindowEvent { event, .. } => {
             match event {
                 WindowEvent::CloseRequested => {
-                    info!("Bye now...");
-                    world_state.is_running = false;
-                    buffer.delete();
-                    *control_flow = ControlFlow::Exit
+                    actions.push(Action::AppExit);
                 }
 
                 WindowEvent::Resized(size) => {
                     let size = size.to_logical::<i32>(1.0);
-                    // bind size
-                    world_state.width = size.width;
-                    world_state.height = size.height;
+                    actions.push(Action::WindowResize((size.width, size.height)))
                 }
 
                 WindowEvent::KeyboardInput { input, .. } => {
@@ -47,61 +37,33 @@ pub fn handle_events<T>(
                         if let Some(keycode) = input.virtual_keycode {
                             match keycode {
                                 VirtualKeyCode::Escape => {
-                                    info!("Bye now...");
-                                    world_state.is_running = false;
-                                    buffer.delete();
-                                    *control_flow = ControlFlow::Exit;
+                                    actions.push(Action::AppExit);
                                 }
 
                                 // Timeline controls
                                 VirtualKeyCode::Space => {
-                                    world_state.play_mode = match world_state.play_mode {
-                                        PlayMode::Playing => {
-                                            log::info!("Paused");
-                                            PlayMode::Paused
-                                        }
-                                        PlayMode::Paused => {
-                                            log::info!("Playing");
-                                            timer.start();
-                                            PlayMode::Playing
-                                        }
-                                    }
+                                    actions.push(Action::TogglePlayPause);
                                 }
                                 VirtualKeyCode::Right => {
-                                    world_state.playback_time = seek(
-                                        world_state.playback_time,
-                                        PlaybackControl::Forward(1.0),
-                                    )
+                                    actions.push(Action::TimeForward(1.0));
                                 }
                                 VirtualKeyCode::Left => {
-                                    world_state.playback_time = seek(
-                                        world_state.playback_time,
-                                        PlaybackControl::Rewind(1.0),
-                                    )
+                                    actions.push(Action::TimeRewind(1.0));
                                 }
                                 VirtualKeyCode::Key0 => {
-                                    world_state.playback_time =
-                                        seek(world_state.playback_time, PlaybackControl::Stop)
+                                    actions.push(Action::TimeStop);
                                 }
+
                                 // Feature controls
                                 VirtualKeyCode::Key1 => {
-                                    if shader.use_camera_integration {
-                                        info!("Disabling camera integration");
-                                        shader.use_camera_integration = false;
-                                        shader.reload().expect("Expected successful shader reload");
-                                    }
+                                    actions.push(Action::CameraToggleIntegration(false));
                                 }
                                 VirtualKeyCode::Key2 => {
-                                    if !shader.use_camera_integration {
-                                        info!("Enabling camera integration. Please use '#pragma skuggbox(camera)' in your shader");
-                                        shader.use_camera_integration = true;
-                                        shader.reload().expect("Expected successful shader reload");
-                                    }
+                                    actions.push(Action::CameraToggleIntegration(true));
                                 }
                                 VirtualKeyCode::Period => {
                                     // reset all camera settings
-                                    world_state.camera = Box::from(OrbitCamera::default());
-                                    world_state.mouse.delta = Vec2::new(0.0, 0.0);
+                                    actions.push(Action::CameraReset);
                                 }
                                 _ => {}
                             }
@@ -112,16 +74,16 @@ pub fn handle_events<T>(
                 _ => {}
             }
 
-            world_state.mouse.handle_window_events(event);
-            world_state.camera.handle_window_events(event);
-            world_state
+            app_state.mouse.handle_window_events(event);
+            app_state.camera.handle_window_events(event);
+            app_state
                 .camera
-                .handle_mouse(&world_state.mouse, world_state.delta_time);
+                .handle_mouse(&app_state.mouse, app_state.delta_time);
         }
 
         Event::MainEventsCleared => {
-            if matches!(world_state.play_mode, PlayMode::Playing) {
-                world_state.playback_time += world_state.delta_time;
+            if matches!(app_state.play_mode, PlayMode::Playing) {
+                app_state.playback_time += app_state.delta_time;
             }
 
             *control_flow = ControlFlow::Exit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all, future_incompatible, nonstandard_style, rust_2018_idioms)]
 
+pub mod actions;
 pub mod app;
 pub mod buffer;
 pub mod camera;
@@ -16,6 +17,7 @@ pub mod uniforms;
 pub mod utils;
 pub mod window;
 
+pub use actions::*;
 pub use app::*;
 pub use buffer::*;
 pub use camera::*;

--- a/src/shader/pre_processor.rs
+++ b/src/shader/pre_processor.rs
@@ -101,7 +101,7 @@ impl PreProcessor {
         }
     }
 
-    pub fn reload(&mut self) {
+    pub fn pre_process(&mut self) {
         match read_shader_src(self.main_shader_path.clone()) {
             Ok(src) => self.process(src),
             Err(e) => error!("Could not re-compile shader {:?}", e),

--- a/src/shader/program.rs
+++ b/src/shader/program.rs
@@ -18,6 +18,14 @@ pub enum ShaderError {
 }
 
 #[derive(Clone)]
+pub struct ShaderLocations {
+    pub resolution: i32,
+    pub time: i32,
+    pub time_delta: i32,
+    pub mouse: i32,
+}
+
+#[derive(Clone)]
 pub struct ShaderProgram {
     pub id: gl::types::GLuint,
 }
@@ -79,6 +87,21 @@ impl ShaderProgram {
     ) -> anyhow::Result<Self, ShaderError> {
         let id = shader_from_string(source, shader_type)?;
         Ok(ShaderProgram { id })
+    }
+
+    #[allow(temporary_cstring_as_ptr)]
+    pub fn uniform_location(&self, uniform_name: &str) -> i32 {
+        unsafe { gl::GetUniformLocation(self.id, CString::new(uniform_name).unwrap().as_ptr()) }
+    }
+
+    /// Extract some common uniform locations
+    pub fn uniform_locations(&self) -> ShaderLocations {
+        ShaderLocations {
+            resolution: self.uniform_location("iResolution"),
+            time: self.uniform_location("iTime"),
+            time_delta: self.uniform_location("iTimeDelta"),
+            mouse: self.uniform_location("iMouse"),
+        }
     }
 }
 

--- a/src/shader/service.rs
+++ b/src/shader/service.rs
@@ -1,16 +1,10 @@
 use log;
-use std::ffi::CString;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 
 use crate::shader::{find_included_files, PreProcessor, ShaderError};
 use crate::{PreProcessorConfig, ShaderLocations, ShaderProgram};
-
-#[allow(temporary_cstring_as_ptr)]
-pub fn get_uniform_location(program: &ShaderProgram, uniform_name: &str) -> i32 {
-    unsafe { gl::GetUniformLocation(program.id, CString::new(uniform_name).unwrap().as_ptr()) }
-}
 
 /// The SkuggboxShader encapsulates everything we need to load,process and render a shader program
 pub struct SkuggboxShader {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{CameraModel, Mouse, OrbitCamera};
+use crate::{CameraModel, Mouse, OrbitCamera, Timer};
 use serde::{Deserialize, Serialize};
 
 pub struct AppState {
@@ -6,6 +6,7 @@ pub struct AppState {
     pub height: i32,
     /// App state - is the application running?
     pub is_running: bool,
+    pub timer: Timer,
     pub delta_time: f32,
     pub playback_time: f32,
     pub mouse: Mouse,
@@ -20,6 +21,7 @@ impl Default for AppState {
             width: 1024,
             height: 768,
             is_running: true,
+            timer: Timer::default(),
             delta_time: 0.0,
             playback_time: 0.0,
             mouse: Mouse::default(),

--- a/tests/shader_include.rs
+++ b/tests/shader_include.rs
@@ -8,7 +8,7 @@ fn test_shader_reload() {
         use_camera_integration: false,
     };
     let mut pre_processor = PreProcessor::new(shader_path, config);
-    pre_processor.reload();
+    pre_processor.pre_process();
     dbg!(&pre_processor.shader_src);
     assert_eq!(pre_processor.shader_src.contains("#pragma include"), false);
 }
@@ -20,7 +20,7 @@ fn test_camera_integration() {
         use_camera_integration: false,
     };
     let mut pre_processor = PreProcessor::new(shader_path, config);
-    pre_processor.reload();
+    pre_processor.pre_process();
     dbg!(&pre_processor.shader_src);
 
     let lines = pre_processor.shader_src.lines().count();

--- a/tests/shader_include.rs
+++ b/tests/shader_include.rs
@@ -4,7 +4,10 @@ use std::path::PathBuf;
 #[test]
 fn test_shader_reload() {
     let shader_path = PathBuf::from("./tests/files/main_test.glsl");
-    let mut pre_processor = PreProcessor::new(shader_path);
+    let config = PreProcessorConfig {
+        use_camera_integration: false,
+    };
+    let mut pre_processor = PreProcessor::new(shader_path, config);
     pre_processor.reload();
     dbg!(&pre_processor.shader_src);
     assert_eq!(pre_processor.shader_src.contains("#pragma include"), false);
@@ -13,7 +16,10 @@ fn test_shader_reload() {
 #[test]
 fn test_camera_integration() {
     let shader_path = PathBuf::from("./tests/files/camera_integration_test.glsl");
-    let mut pre_processor = PreProcessor::new(shader_path);
+    let config = PreProcessorConfig {
+        use_camera_integration: false,
+    };
+    let mut pre_processor = PreProcessor::new(shader_path, config);
     pre_processor.reload();
     dbg!(&pre_processor.shader_src);
 


### PR DESCRIPTION
Split input and actions to make it easier to see when side effects occurs based on user input.

Move loose shader related functions into `SkuggboxShader` implementation.
