### PR TITLE
Add snapshot functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,6 +1496,7 @@ dependencies = [
  "regex",
  "serde",
  "simple_logger",
+ "time",
  "tracing",
  "ui-backend",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ raw-window-handle = "0.5.0"
 regex = "1.9"
 serde = { version = "1.0", features = ["derive"] }
 simple_logger = "1"
+# simple_logger is dependent on `time`.
+time = { version = "0.3.26", features = ["local-offset"]}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 quote = "1.0"
 #clap = { git = "https://github.com/clap-rs/clap/", version = "3.0.0-beta.4" } #clap-v3 = "3.0.0-beta.1"

--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ cargo run --release -- --help
 
 ### Misc
 See file `.ignore` for directories and files ignored by `cargo watch`
+
+
+## Shortcuts
+
+```text
+F12 => Take snapshot of current shader. Saved into shader_dir/snapshots/snapshot-<datetime>.glsl
+```

--- a/components/glsl-watcher/src/lib.rs
+++ b/components/glsl-watcher/src/lib.rs
@@ -17,20 +17,20 @@ pub fn watch_all(sender: Sender<PathBuf>, files: Vec<PathBuf>) {
     let (tx, rx) = channel();
     let mut watcher = RecommendedWatcher::new(tx, Config::default()).unwrap();
 
-    let directories: Vec<PathBuf> = files
+    let file_paths: Vec<PathBuf> = files
         .iter()
         .filter_map(|p| fs::canonicalize(p).ok())
         .collect();
 
     println!("Watching files shaders in:");
-    for dir in &directories {
+    for path in &file_paths {
         watcher
-            .watch(dir.as_path(), RecursiveMode::Recursive)
+            .watch(path.as_path(), RecursiveMode::Recursive)
             .unwrap(); // TODO: Replace with GLSLWatcherError
-        println!("   {:?}", dir);
+        println!("   {:?}", path);
     }
 
-    watch_loop(sender, rx, directories);
+    watch_loop(sender, rx, file_paths);
 }
 
 fn watch_loop(

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -30,6 +30,7 @@ pub enum Action {
     ToggleFullscreen,
     Screenshot,
     PrintSource,
+    TakeSnapshot,
 }
 
 pub fn handle_actions(
@@ -150,6 +151,8 @@ pub fn handle_actions(
                     app_state.camera_pos.z = 0.0;
                 }
             },
+
+            Action::TakeSnapshot => shader_service.save_snapshot(),
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -97,6 +97,7 @@ pub fn handle_events<T>(
                                 VirtualKeyCode::F11 => actions.push(Action::ToggleFullscreen),
 
                                 VirtualKeyCode::P => actions.push(Action::PrintSource),
+                                VirtualKeyCode::F12 => actions.push(Action::TakeSnapshot),
                                 _ => {}
                             }
                         }

--- a/src/shader/skuggbox_shader.rs
+++ b/src/shader/skuggbox_shader.rs
@@ -19,6 +19,7 @@ pub struct ShaderContent {
     /// The filename constitutes the `shader_id`
     /// <shader_id>.glsl
     pub shader_id: String,
+    /// Path to the main shader, full path + filename
     pub main_shader_path: PathBuf,
     pub parts: BTreeMap<PathBuf, Part>,
     /// contains the final shader after it's been pre-processed


### PR DESCRIPTION
Adds a super simple snapshot functionality.

F12 saves the current (non-errored) shader into `shader-dir/snapshots/<datetime>.glsl
